### PR TITLE
fix: Prevent duplicate widget IDs on ListView refresh

### DIFF
--- a/src/rwreader/ui/screens/article_list.py
+++ b/src/rwreader/ui/screens/article_list.py
@@ -124,6 +124,11 @@ class ArticleListScreen(Screen):
     def populate_list(self) -> None:
         """Populate ListView with articles."""
         list_view = self.query_one("#article_list", ListView)
+
+        # Remove all existing items explicitly to avoid duplicate IDs
+        for child in list(list_view.children):
+            child.remove()
+
         list_view.clear()
 
         for article in self.articles:

--- a/src/rwreader/ui/screens/category_list.py
+++ b/src/rwreader/ui/screens/category_list.py
@@ -96,6 +96,11 @@ class CategoryListScreen(Screen):
     def populate_list(self) -> None:
         """Populate the ListView with categories."""
         list_view = self.query_one("#category_list", ListView)
+
+        # Remove all existing items explicitly to avoid duplicate IDs
+        for child in list(list_view.children):
+            child.remove()
+
         list_view.clear()
 
         # Category icons and names


### PR DESCRIPTION
## Summary
- Fixed duplicate widget ID error when refreshing category list screen
- Applied same fix to article list screen for consistency
- Explicitly removes child widgets before clearing ListView to ensure IDs are properly released

## Root Cause
When the `action_refresh()` method was called, the `populate_list()` method would call `list_view.clear()`, but there was a timing issue where widget IDs weren't fully released before new widgets with the same IDs were created, causing the error:
```
Tried to insert a widget with ID 'cat_inbox', but a widget already exists with that ID
```

## Solution
Added an explicit loop to remove all children before calling `clear()`:
```python
# Remove all existing items explicitly to avoid duplicate IDs
for child in list(list_view.children):
    child.remove()

list_view.clear()
```

## Testing
- Verified code passes ruff linting and formatting
- Git diff shows only the intended changes
- Applied to both `category_list.py` and `article_list.py` for defensive consistency

## Files Changed
- `src/rwreader/ui/screens/category_list.py` - Fixed populate_list() method
- `src/rwreader/ui/screens/article_list.py` - Applied same fix for consistency

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)