### PR TITLE
fix: Improve category refresh with immediate UI clear and comprehensive logging

### DIFF
--- a/src/rwreader/ui/screens/category_list.py
+++ b/src/rwreader/ui/screens/category_list.py
@@ -62,17 +62,24 @@ class CategoryListScreen(Screen):
             return
 
         try:
-            # Show loading message
-            self.notify("Loading categories...", title="Loading")
+            logger.debug(f"load_categories called with refresh={refresh}")
 
             # Get counts for each category using the client's methods
             client = self.app.client  # type: ignore
 
             # Fetch data from API (or cache if not refreshing)
             # Use refresh=True to force API call, otherwise use cache if available
+            logger.debug("Fetching inbox data...")
             inbox_data = client.get_inbox(refresh=refresh)
+            logger.debug(f"Got {len(inbox_data)} inbox items")
+
+            logger.debug("Fetching feed data...")
             feed_data = client.get_feed(refresh=refresh)
+            logger.debug(f"Got {len(feed_data)} feed items")
+
+            logger.debug("Fetching later data...")
             later_data = client.get_later(refresh=refresh)
+            logger.debug(f"Got {len(later_data)} later items")
 
             # Calculate counts
             inbox_count = len(inbox_data) if inbox_data else 0
@@ -84,6 +91,10 @@ class CategoryListScreen(Screen):
             )
             later_count = len(later_data) if later_data else 0
 
+            logger.debug(
+                f"Calculated counts: inbox={inbox_count}, feed={feed_count}, later={later_count}"
+            )
+
             self.categories = {
                 "inbox": inbox_count,
                 "feed": feed_count,
@@ -92,45 +103,64 @@ class CategoryListScreen(Screen):
             }
 
             # Populate the list
+            logger.debug("Populating list...")
             self.populate_list()
+            logger.debug("List populated successfully")
+
+            self.notify("Categories loaded", title="Success")
 
         except Exception as e:
-            logger.error(f"Error loading categories: {e}")
+            logger.error(f"Error loading categories: {e}", exc_info=True)
             self.notify(f"Error loading categories: {e}", severity="error")
 
     def populate_list(self) -> None:
         """Populate the ListView with categories."""
-        list_view = self.query_one("#category_list", ListView)
+        try:
+            logger.debug("populate_list called")
+            list_view = self.query_one("#category_list", ListView)
 
-        # Remove all existing items explicitly to avoid duplicate IDs
-        for child in list(list_view.children):
-            child.remove()
+            # Remove all existing items explicitly to avoid duplicate IDs
+            existing_count = len(list(list_view.children))
+            logger.debug(f"Removing {existing_count} existing items")
+            for child in list(list_view.children):
+                child.remove()
 
-        list_view.clear()
+            list_view.clear()
+            logger.debug("ListView cleared")
 
-        # Category icons and names
-        categories = [
-            ("inbox", "📥", "Inbox"),
-            ("later", "⏰", "Later"),
-            ("feed", "📰", "Feed"),
-            ("archive", "📦", "Archive"),
-        ]
+            # Category icons and names
+            categories = [
+                ("inbox", "📥", "Inbox"),
+                ("later", "⏰", "Later"),
+                ("feed", "📰", "Feed"),
+                ("archive", "📦", "Archive"),
+            ]
 
-        for category_id, icon, name in categories:
-            count = self.categories.get(category_id, 0)
-            if count >= 0:
-                display_text = f"{icon} {name} ({count})"
-            else:
-                display_text = f"{icon} {name}"
+            logger.debug(f"Adding categories with counts: {self.categories}")
+            for category_id, icon, name in categories:
+                count = self.categories.get(category_id, 0)
+                if count >= 0:
+                    display_text = f"{icon} {name} ({count})"
+                else:
+                    display_text = f"{icon} {name}"
 
-            item = ListItem(Static(display_text, markup=False), id=f"cat_{category_id}")
-            item.data = {"category": category_id}  # type: ignore
-            list_view.append(item)
+                logger.debug(f"Creating item for {category_id}: {display_text}")
+                item = ListItem(
+                    Static(display_text, markup=False), id=f"cat_{category_id}"
+                )
+                item.data = {"category": category_id}  # type: ignore
+                list_view.append(item)
+                logger.debug(f"Appended item {category_id}")
 
-        # Focus the list and select first item
-        list_view.focus()
-        if len(list_view.children) > 0:
-            list_view.index = 0
+            # Focus the list and select first item
+            list_view.focus()
+            if len(list_view.children) > 0:
+                list_view.index = 0
+            logger.debug(f"List populated with {len(list_view.children)} items")
+
+        except Exception as e:
+            logger.error(f"Error in populate_list: {e}", exc_info=True)
+            raise
 
     def action_cursor_down(self) -> None:
         """Move cursor down."""
@@ -171,9 +201,26 @@ class CategoryListScreen(Screen):
 
     def action_refresh(self) -> None:
         """Refresh category counts."""
-        # Load categories with refresh=True to fetch fresh data from API
+        logger.info("action_refresh called")
+
+        # Clear the list view immediately to show refresh is happening
+        list_view = self.query_one("#category_list", ListView)
+        logger.debug(f"Clearing {len(list(list_view.children))} items from view")
+        for child in list(list_view.children):
+            child.remove()
+        list_view.clear()
+        logger.debug("ListView cleared in action_refresh")
+
+        # Clear the client cache and reload (same pattern as article_list)
+        if hasattr(self.app, "client"):
+            logger.debug("Clearing client cache")
+            self.app.client.clear_cache()  # type: ignore
+
+        # Load fresh data from API
+        logger.debug("Calling load_categories with refresh=True")
         self.load_categories(refresh=True)
-        self.notify("Categories refreshed", title="Refresh")
+        self.notify("Refreshing categories...", title="Refresh")
+        logger.debug("action_refresh completed")
 
     def action_help(self) -> None:
         """Show help screen."""


### PR DESCRIPTION
## Summary
- Completely revised category refresh mechanism to match article_list pattern
- Added immediate UI clearing to provide visual feedback
- Added comprehensive debug logging to help diagnose any issues

## Problem
After PRs #25 and #27, the refresh still wasn't working correctly. The issue appears to be related to timing and the async nature of the `@work` decorator.

## Root Cause Analysis
The previous approach had several potential issues:
1. UI wasn't cleared immediately, causing confusion about whether refresh was working
2. Relied on client methods to clear cache via `refresh=True`, but timing might be off
3. Lacked visibility into what was actually happening during refresh
4. Different pattern from article_list which seems to work

## Solution
This PR implements a more robust approach:

### 1. Immediate UI Feedback
```python
# Clear the list view immediately when refresh is triggered
list_view = self.query_one("#category_list", ListView)
for child in list(list_view.children):
    child.remove()
list_view.clear()
```
This happens synchronously in `action_refresh()` so the user sees immediate feedback.

### 2. Explicit Cache Clearing
```python
# Match article_list pattern
if hasattr(self.app, "client"):
    self.app.client.clear_cache()
```
Explicitly clear the cache before calling `load_categories()`, matching the working pattern in article_list.

### 3. Comprehensive Debug Logging
Added logging at every step to help diagnose issues:
- When action_refresh is called
- When ListView is cleared
- When cache is cleared  
- When each API call is made and how many items returned
- Calculated counts for each category
- When list is being populated
- Any errors with full stack traces

### 4. Better User Notifications
- "Refreshing categories..." when refresh starts (indicates in-progress)
- "Categories loaded" when complete (indicates success)
- Error notifications with full error messages

## Testing
- Code passes ruff linting and formatting
- Ready for manual testing with debug logging enabled

## How to Test with Logging
Run with debug logging:
```bash
rwreader --debug
```

Then check `~/.rwreader/logs/rwreader.log` for detailed execution trace when you press 'r' to refresh.

The logs will show exactly:
- When refresh is triggered
- How many items are cleared from UI
- What data is fetched from API (count for each category)
- What counts are calculated
- How the list is repopulated

This will help us identify any remaining issues.

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)