### PR TITLE
fix: Add @work decorator to delete actions for proper async context

### DIFF
--- a/src/rwreader/ui/screens/article_list.py
+++ b/src/rwreader/ui/screens/article_list.py
@@ -267,6 +267,7 @@ class ArticleListScreen(Screen):
             logger.error(f"Error moving article: {e}")
             self.notify(f"Error: {e}", severity="error")
 
+    @work
     async def action_delete_article(self) -> None:
         """Delete article (with confirmation)."""
         list_view = self.query_one(ListView)

--- a/src/rwreader/ui/screens/article_reader.py
+++ b/src/rwreader/ui/screens/article_reader.py
@@ -233,6 +233,7 @@ class ArticleReaderScreen(Screen):
             logger.error(f"Error moving article: {e}")
             self.notify(f"Error: {e}", severity="error")
 
+    @work
     async def action_delete(self) -> None:
         """Delete this article (with confirmation)."""
         article_id = str(self.article.get("id"))


### PR DESCRIPTION
## Summary
- Fixed NoActiveWorker error when pressing 'D' to delete an article in the article reader
- Added @work decorator to both delete actions for consistency

## Problem
When pressing 'D' to delete an article while viewing it, the app crashed with:
\`\`\`
NoActiveWorker: push_screen must be run from a worker when \`wait_for_dismiss\` is True
\`\`\`

## Root Cause
The \`action_delete\` method in ArticleReaderScreen (and \`action_delete_article\` in ArticleListScreen) use \`await self.app.push_screen_wait()\`, which internally calls \`push_screen\` with \`wait_for_dismiss=True\`.

In Textual, when an action needs to wait for a screen to be dismissed (using \`push_screen_wait\`), it must run in a worker context. While Textual should automatically run async actions in workers, there are cases where this doesn't happen reliably.

## Solution
Add explicit \`@work\` decorator to ensure the methods run in a worker context:

**article_reader.py:236**
\`\`\`python
@work
async def action_delete(self) -> None:
    """Delete this article (with confirmation)."""
    # ... uses push_screen_wait ...
\`\`\`

**article_list.py:270**
\`\`\`python
@work
async def action_delete_article(self) -> None:
    """Delete article (with confirmation)."""
    # ... uses push_screen_wait ...
\`\`\`

## Why Both Files
While the user only reported the error in article_reader, article_list has the same pattern (async action using push_screen_wait without @work). Adding the decorator to both:
1. Ensures consistency across the codebase
2. Prevents potential future issues
3. Makes the code more explicit and self-documenting

## Testing
- Press 'D' while viewing an article - should show confirmation dialog without error
- Press 'D' while in article list - should work as before
- Both actions should properly wait for confirmation and handle the result

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)